### PR TITLE
Graphics Namespace Condensing

### DIFF
--- a/Core/Graphics/Automators/IDrawAdditive.cs
+++ b/Core/Graphics/Automators/IDrawAdditive.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.Xna.Framework.Graphics;
 
-namespace Luminance.Core.Graphics.Automators
+namespace Luminance.Core.Graphics
 {
     public interface IDrawAdditive
     {

--- a/Core/Graphics/Automators/IDrawLocalDistortion.cs
+++ b/Core/Graphics/Automators/IDrawLocalDistortion.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.Xna.Framework.Graphics;
 
-namespace Luminance.Core.Graphics.Automators
+namespace Luminance.Core.Graphics
 {
     public interface IDrawLocalDistortion
     {

--- a/Core/Graphics/Automators/InterfacedProjectileDrawSystem.cs
+++ b/Core/Graphics/Automators/InterfacedProjectileDrawSystem.cs
@@ -4,7 +4,7 @@ using Microsoft.Xna.Framework.Graphics;
 using Terraria;
 using Terraria.ModLoader;
 
-namespace Luminance.Core.Graphics.Automators
+namespace Luminance.Core.Graphics
 {
     [Autoload(Side = ModSide.Client)]
     public class InterfacedProjectileDrawSystem : ModSystem

--- a/Core/Graphics/Automators/ManagedRenderTarget.cs
+++ b/Core/Graphics/Automators/ManagedRenderTarget.cs
@@ -4,7 +4,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Terraria;
 
-namespace Luminance.Core.Graphics.Automators
+namespace Luminance.Core.Graphics
 {
     [DebuggerDisplay("Width: {target?.Width ?? 0}, Height: {target?.Height ?? 0}, Uninitialized: {IsUninitialized}, Time since last usage: {TimeSinceLastUsage} frame(s)")]
     public class ManagedRenderTarget : IDisposable

--- a/Core/Graphics/Automators/RenderTargetManager.cs
+++ b/Core/Graphics/Automators/RenderTargetManager.cs
@@ -3,7 +3,7 @@ using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ModLoader;
 
-namespace Luminance.Core.Graphics.Automators
+namespace Luminance.Core.Graphics
 {
     public class RenderTargetManager : ModSystem
     {

--- a/Core/Graphics/Shaders/ManagedShader.cs
+++ b/Core/Graphics/Shaders/ManagedShader.cs
@@ -6,7 +6,7 @@ using ReLogic.Content;
 using Terraria;
 using Terraria.ID;
 
-namespace Luminance.Core.Graphics.Shaders
+namespace Luminance.Core.Graphics
 {
     [DebuggerDisplay("Shader - '{Name}'")]
     public sealed class ManagedShader

--- a/Core/Graphics/Shaders/ShaderManager.cs
+++ b/Core/Graphics/Shaders/ShaderManager.cs
@@ -6,7 +6,7 @@ using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 
-namespace Luminance.Core.Graphics.Shaders
+namespace Luminance.Core.Graphics
 {
     public class ShaderManager : ModSystem
     {

--- a/Core/Graphics/SpecificEffectManagers/CameraPanSystem.cs
+++ b/Core/Graphics/SpecificEffectManagers/CameraPanSystem.cs
@@ -3,7 +3,7 @@ using Terraria;
 using Terraria.Graphics;
 using Terraria.ModLoader;
 
-namespace Luminance.Core.Graphics.SpecificEffectManagers
+namespace Luminance.Core.Graphics
 {
     [Autoload(Side = ModSide.Client)]
     public class CameraPanSystem : ModSystem

--- a/Core/Graphics/SpecificEffectManagers/ScreenShakeSystem.cs
+++ b/Core/Graphics/SpecificEffectManagers/ScreenShakeSystem.cs
@@ -4,7 +4,7 @@ using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ModLoader;
 
-namespace Luminance.Core.Graphics.SpecificEffectManagers
+namespace Luminance.Core.Graphics
 {
     public class ScreenShakeSystem : ModSystem
     {


### PR DESCRIPTION
Makes all sub-namepaces in the Luminance,Core.Graphics directory use that as its namespace, to avoid needing excess using statements to use features.