### PR TITLE
ModCalls Caching Optimization

### DIFF
--- a/Core/ModCalls/ModCall.cs
+++ b/Core/ModCalls/ModCall.cs
@@ -7,21 +7,9 @@ namespace Luminance.Core.ModCalls
 {
     public abstract class ModCall : ILoadable
     {
-        ///<summary>
-        /// Once a call makes it to a public version, NEVER delete it from here.
-        /// </summary>
-        public abstract IEnumerable<string> CallCommands
-        {
-            get;
-        }
+        internal IEnumerable<string> CallCommands;
 
-        /// <summary>
-        /// The ordered types that the args must be. Set as null if none are needed.
-        /// </summary>
-        public abstract IEnumerable<Type> InputTypes
-        {
-            get;
-        }
+        internal IEnumerable<Type> InputTypes;
 
         // WHY doesnt ILoadable.Unload() pass the mod??
         public Mod AssosiatedMod
@@ -68,9 +56,21 @@ namespace Luminance.Core.ModCalls
         /// <returns></returns>
         protected abstract object SafeProcess(params object[] argsWithoutCommand);
 
+        ///<summary>
+        /// Once a call makes it to a public version, NEVER delete it from here.
+        /// </summary>
+        public abstract IEnumerable<string> GetCallCommands();
+
+        /// <summary>
+        /// The ordered types that the args must be. Return as null if none are needed.
+        /// </summary>
+        public abstract IEnumerable<Type> GetInputTypes();
+
         public void Load(Mod mod)
         {
             AssosiatedMod = mod;
+            CallCommands = GetCallCommands();
+            InputTypes = GetInputTypes();
             ModCallManager.RegisterModCall(mod, this);
         }
 

--- a/Core/ModCalls/ModCallManager.cs
+++ b/Core/ModCalls/ModCallManager.cs
@@ -9,7 +9,7 @@ namespace Luminance.Core.ModCalls
     {
         public static object DefaultObject => new();
 
-        public static readonly Dictionary<string, List<ModCall>> ModCallsByMods = new();
+        public static readonly Dictionary<string, List<ModCall>> ModCallsByMods = [];
 
         /// <summary>
         /// Call this from YourMod.Call(params object[] args).
@@ -34,7 +34,7 @@ namespace Luminance.Core.ModCalls
         private static List<ModCall> GetCorrectModCalls(string modName)
         {
             if (!ModCallsByMods.ContainsKey(modName))
-                ModCallsByMods[modName] = new();
+                ModCallsByMods[modName] = [];
             return ModCallsByMods[modName];
         }
 


### PR DESCRIPTION
- The IEnumerables are cached on loading instead of recreated on accessing.