### PR TITLE
Shader compiler additions and fixes

### DIFF
--- a/Core/Graphics/Shaders/ShaderRecompilationMonitor.cs
+++ b/Core/Graphics/Shaders/ShaderRecompilationMonitor.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
 using Terraria;
@@ -220,7 +221,7 @@ namespace Luminance.Core.Graphics
             easyXnb.Start();
             if (!easyXnb.WaitForExit(3000))
             {
-                Main.NewText("Shader compiler timed out. Likely error.");
+                Main.NewText("Shader compiler timed out. Likely error.", Color.OrangeRed);
                 easyXnb.Kill();
                 return;
             }
@@ -241,10 +242,12 @@ namespace Luminance.Core.Graphics
             string modName = $"{watcher.ModName}.";
             string compiledXnbPath = CompilerDirectory + "\\" + Path.GetFileNameWithoutExtension(shaderPath) + ".xnb";
             string originalXnbPath = shaderPath.Replace(".fx", ".xnb");
-            string shaderPathInCompilerDirectory = compilerDirectory + Path.GetFileName(shaderPath);
+            string shaderPathInCompilerDirectory = compilerDirectory + Path.DirectorySeparatorChar + Path.GetFileName(shaderPath);
+
+            if (File.Exists(originalXnbPath))
+                File.Delete(originalXnbPath);
 
             // Copy over the XNB from the compiler, and delete the copy in the Compiler folder.
-            File.Delete(originalXnbPath);
             try
             {
                 File.Copy(compiledXnbPath, originalXnbPath);

--- a/Luminance.cs
+++ b/Luminance.cs
@@ -23,14 +23,13 @@ namespace Luminance
         /// </summary>
         public override void PostSetupContent()
         {
-            // Go through every mod and check for effects to autoload.
             foreach (Mod mod in ModLoader.Mods)
             {
                 HookHelper.LoadHookInterfaces(mod);
+                ShaderRecompilationMonitor.LoadForMod(mod);
                 ShaderManager.LoadShaders(mod);
                 AtlasManager.InitializeModAtlases(mod);
                 ParticleManager.InitializeManualRenderers(mod);
-                ShaderRecompilationMonitor.LoadForMod(mod);
             }
 
             // Mark loading operations as finished.


### PR DESCRIPTION
- Shaders without a compiled xnb now get automatically compiled when entering a world.
- Fixed files being left behind in the compiler directory.